### PR TITLE
refactor (*): renamed project to "duma"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,5 +1,5 @@
 [root]
-name = "rget"
+name = "duma"
 version = "0.1.0"
 dependencies = [
  "assert_cli 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rget"
+name = "duma"
 version = "0.1.0"
 authors = ["Matt Gathu <mattgathu@gmail.com>"]
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-## rget
+## duma
 
-[![Build Status](https://travis-ci.org/mattgathu/rget.svg?branch=master)](https://travis-ci.org/mattgathu/rget)
-[![Build status](https://ci.appveyor.com/api/projects/status/jyr43c87ee78bf7u?svg=true)](https://ci.appveyor.com/project/mattgathu/rget)
+[![Build Status](https://travis-ci.org/mattgathu/duma.svg?branch=master)](https://travis-ci.org/mattgathu/duma)
+[![Build status](https://ci.appveyor.com/api/projects/status/jyr43c87ee78bf7u?svg=true)](https://ci.appveyor.com/project/mattgathu/duma)
 
 A wget clone written in Rust.
 
@@ -15,12 +15,12 @@ A wget clone written in Rust.
 ## usage
 
 ```
-Rget 0.1.0
+Duma 0.1.0
 Matt Gathu <mattgathu@gmail.com>
 wget clone written in Rust
 
 USAGE:
-    rget [FLAGS] [OPTIONS] <URL>
+    duma [FLAGS] [OPTIONS] <URL>
 
 FLAGS:
     -c, --continue    resume getting a partially-downloaded file

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 extern crate clap;
-extern crate rget;
+extern crate duma;
 
 use std::process;
 
-use rget::download::{ftp_download, http_download};
-use rget::utils;
+use duma::download::{ftp_download, http_download};
+use duma::utils;
 
 use clap::{App, Arg};
 
@@ -20,7 +20,7 @@ fn main() {
 }
 
 fn run() -> Result<(), Box<::std::error::Error>> {
-    let args = App::new("Rget")
+    let args = App::new("Duma")
         .version("0.1.0")
         .author("Matt Gathu <mattgathu@gmail.com>")
         .about("wget clone written in Rust")

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5,7 +5,7 @@ mod integration {
     use assert_cli;
 
     #[test]
-    fn calling_rget_without_args() {
+    fn calling_duma_without_args() {
         assert_cli::Assert::main_binary()
             .fails()
             .and()
@@ -15,7 +15,7 @@ mod integration {
     }
 
     #[test]
-    fn calling_rget_with_invalid_url() {
+    fn calling_duma_with_invalid_url() {
         assert_cli::Assert::main_binary()
             .with_args(&["wwww.shouldnotwork.com"])
             .fails()


### PR DESCRIPTION
renamed `rget` to `duma` due an already existing crate