### PR TITLE
Use consistent exit point for program

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ fn run() -> Result<(), Box<::std::error::Error>> {
         (@arg AGENT: -U --useragent +takes_value "identify as AGENT instead of Duma/VERSION")
         (@arg SECONDS: -T --timeout +takes_value "set all timeout values to SECONDS")
         (@arg URL: +required +takes_value "url to download")
-        ).get_matches();
+        ).get_matches_safe()?;
 
     let url = utils::parse_url(args.value_of("URL").unwrap())?;
     let quiet_mode = args.is_present("quiet");


### PR DESCRIPTION
[`get_matches`](https://docs.rs/clap/2.32.0/clap/struct.App.html#method.get_matches) currently displays an error to the user on failure and calls [`process::exit`](https://doc.rust-lang.org/std/process/fn.exit.html). This means that if some sort of error occurs with CLI parsing, then the end of the `main` function is not reached. While this isn't necessarily a problem here, multiple exit points make the code harder to reason about and can cause errors. I've replaced `get_matches` with [`get_matches_safe`](https://docs.rs/clap/2.32.0/clap/struct.App.html#method.get_matches_safe), which instead of exiting the program returns a [`ClapResult`](https://docs.rs/clap/2.32.0/clap/type.Result.html). The error is then propagated upwards with the `?` operator, allowing for a consistent exit point on error from the program.