### PR TITLE
Add number of connections configuration

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -23,6 +23,7 @@ pub struct Config {
     pub concurrent: bool,
     pub proxies: Option<HashMap<String, String>>,
     pub max_retries: i32,
+    pub num_workers: usize,
     pub bytes_on_disk: Option<u64>,
     pub chunk_sizes: Option<Vec<(u64, u64)>>,
     pub chunk_sz: usize,
@@ -246,7 +247,7 @@ impl HttpDownload {
         } else {
             bail!("concurrent download: server did not return content-length header")
         };
-        let n_workers = 8;
+        let n_workers = self.opts.num_workers;
         let chunk_sizes = self
             .opts
             .chunk_sizes

--- a/src/download.rs
+++ b/src/download.rs
@@ -168,6 +168,11 @@ pub fn http_download(url: Url, args: &ArgMatches, version: &str) -> Fallible<()>
     } else {
         None
     };
+    let num_workers = if let Some(num) = args.value_of("NUM_CONNECTIONS") {
+        num.parse::<usize>()?
+    } else {
+        8usize
+    };
     let proxies = get_http_proxies();
     let state_file_exists = Path::new(&format!("{}.st", fname)).exists();
 
@@ -193,6 +198,7 @@ pub fn http_download(url: Url, args: &ArgMatches, version: &str) -> Fallible<()>
         concurrent: concurrent_download,
         proxies,
         max_retries: 100,
+        num_workers,
         bytes_on_disk,
         chunk_sizes,
         chunk_sz: 512_000,

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ fn run() -> Fallible<()> {
     (@arg FILE: -O --output +takes_value "write documents to FILE")
     (@arg AGENT: -U --useragent +takes_value "identify as AGENT instead of Duma/VERSION")
     (@arg SECONDS: -T --timeout +takes_value "set all timeout values to SECONDS")
+    (@arg NUM_CONNECTIONS: -n --num_connections +takes_value "maximum number of concurrent connections (default is 8)")
     (@arg URL: +required +takes_value "url to download")
     )
     .get_matches_safe()?;


### PR DESCRIPTION
Allow user to configure number of concurrent connections.
This translates to the number of workers in the threadpool internally.