### PR TITLE
Fix file corruption bug during concurrent resume

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -179,12 +179,12 @@ impl HttpDownload {
             None => false,
         };
         if server_supports_bytes && self.opts.headers.clone().get(RANGE).is_some() {
-                if self.opts.concurrent {
-                    self.opts.headers.remove(RANGE);
-                }
-                for hook in &self.hooks {
-                    hook.borrow_mut().on_server_supports_resume();
-                }
+            if self.opts.concurrent {
+                self.opts.headers.remove(RANGE);
+            }
+            for hook in &self.hooks {
+                hook.borrow_mut().on_server_supports_resume();
+            }
         }
 
         req = req.headers(self.opts.headers.clone());
@@ -241,15 +241,13 @@ impl HttpDownload {
         } else {
             bail!("concurrent download: server did not return content-length header")
         };
-        let n_workers = self.opts.num_workers;
         let chunk_offsets = self
             .opts
             .chunk_offsets
             .clone()
             .unwrap_or_else(|| self.get_chunk_offsets(ct_len, self.opts.chunk_size));
-        let worker_pool = ThreadPool::new(n_workers);
+        let worker_pool = ThreadPool::new(self.opts.num_workers);
         for offsets in chunk_offsets {
-            debug_assert!(offsets.0 < offsets.1);
             let data_tx = data_tx.clone();
             let errors_tx = errors_tx.clone();
             let url = self.url.clone();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -20,11 +20,18 @@ pub fn gen_error(msg: String) -> Fallible<()> {
     bail!(msg)
 }
 
-pub fn get_file_handle(fname: &str, resume_download: bool) -> io::Result<File> {
+pub fn get_file_handle(fname: &str, resume_download: bool, append: bool) -> io::Result<File> {
     if resume_download && Path::new(fname).exists() {
-        match OpenOptions::new().append(true).open(fname) {
-            Ok(file) => Ok(file),
-            Err(error) => Err(error),
+        if append {
+            match OpenOptions::new().append(true).open(fname) {
+                Ok(file) => Ok(file),
+                Err(error) => Err(error),
+            }
+        } else {
+            match OpenOptions::new().write(true).open(fname) {
+                Ok(file) => Ok(file),
+                Err(error) => Err(error),
+            }
         }
     } else {
         match OpenOptions::new().write(true).create(true).open(fname) {


### PR DESCRIPTION
- change file's open options when resuming concurrent download to be
`write` instead of `append`
- minor code fixes
- remove debug asserts

fixes #6 